### PR TITLE
fix: load QR code library

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
 <!-- Dependencies via CDN (no build step) -->
 <script src="https://cdn.jsdelivr.net/npm/localforage@1.10.0/dist/localforage.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@noble/ed25519@2.1.0/lib/index.umd.min.js"></script>
 
 <script type="module" src="app.js"></script>


### PR DESCRIPTION
## Summary
- Load QR code generation library from a version that provides a browser build to avoid `QRCode is not defined`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68951cbe32508327a2b627bad25cbd01