### PR TITLE
Add identity QR sharing with name

### DIFF
--- a/app.js
+++ b/app.js
@@ -169,6 +169,7 @@ async function refreshIdentities() {
         <div><strong>${value.name}</strong> <span class="pill">${value.algo}</span></div>
         <div class="mono muted">pk: ${b64u(value.pubRaw)}</div>
         <div style="margin-top:6px" class="row">
+          <button class="btn" data-share="${key}">Share</button>
           <button class="btn" data-export="${key}">Export Private (encrypted)</button>
           <button class="btn warn" data-del="${key}">Delete</button>
         </div>
@@ -196,7 +197,13 @@ $('#btn-create-id').addEventListener('click', async () => {
 
 $('#identity-list').addEventListener('click', async (e) => {
   const t = e.target;
-  if (t.dataset.export) {
+  if (t.dataset.share) {
+    const id = t.dataset.share; const rec = await db.ids.getItem(id);
+    const payload = { displayName: rec.name, algo: rec.algo, publicJwk: rec.pubJwk };
+    await QRCode.toCanvas($('#share-qr'), JSON.stringify(payload), { errorCorrectionLevel: 'M', margin: 1, width: 256 });
+    $('#share-name').textContent = rec.name;
+    $('#share-modal').style.display = 'flex';
+  } else if (t.dataset.export) {
     const id = t.dataset.export; const rec = await db.ids.getItem(id);
     const pass = $('#id-pass').value || prompt('Passphrase to encrypt private key export:');
     if (!pass) return;
@@ -208,6 +215,10 @@ $('#identity-list').addEventListener('click', async (e) => {
     await db.ids.removeItem(t.dataset.del);
     await refreshIdentities();
   }
+});
+
+$('#share-close').addEventListener('click', () => {
+  $('#share-modal').style.display = 'none';
 });
 
 $('#btn-import-id').addEventListener('click', async () => {

--- a/index.html
+++ b/index.html
@@ -223,6 +223,15 @@
   </section>
 </main>
 
+<div id="share-modal" class="modal" style="display:none">
+  <div class="inner">
+    <h2>Share Identity</h2>
+    <canvas id="share-qr" width="256" height="256"></canvas>
+    <div id="share-name" class="foot"></div>
+    <div style="margin-top:12px"><button class="btn" id="share-close">Close</button></div>
+  </div>
+</div>
+
 <!-- Dependencies via CDN (no build step) -->
 <script src="https://cdn.jsdelivr.net/npm/localforage@1.10.0/dist/localforage.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.js"></script>

--- a/style.css
+++ b/style.css
@@ -163,3 +163,23 @@ details { margin-top:8px; }
   opacity:.7;
   margin-top:12px;
 }
+
+.modal {
+  position:fixed;
+  top:0;
+  left:0;
+  right:0;
+  bottom:0;
+  background:rgba(0,0,0,.8);
+  display:none;
+  align-items:center;
+  justify-content:center;
+  z-index:1000;
+}
+.modal .inner {
+  background:var(--panel);
+  border:1px solid var(--muted);
+  border-radius:10px;
+  padding:20px;
+  text-align:center;
+}


### PR DESCRIPTION
## Summary
- Add share button for each identity
- Generate QR code with identity name and public key for easy contact import
- Style and display QR in a modal overlay

## Testing
- `node --check app.js`
- `node --check utils.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68951d197fbc8327bb5fd9802b04a244