### PR TITLE
Fix signature verification mismatch with signed comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,14 +141,14 @@
     <div class="card">
       <h2>Sign</h2>
       <div class="row">
-        <div>
-          <label>Signer Identity</label>
-          <select id="sign-identity"></select>
-        </div>
-        <div>
-          <label>Optional note</label>
-          <input id="sign-note" type="text" placeholder="Short note" />
-        </div>
+      <div>
+        <label>Signer Identity</label>
+        <select id="sign-identity"></select>
+      </div>
+      <div>
+        <label>Optional comment</label>
+        <input id="sign-comment" type="text" placeholder="Short comment" />
+      </div>
       </div>
       <div style="margin-top:8px">
         <button class="btn primary" id="btn-sign">Hash + Sign + Embed QR</button>


### PR DESCRIPTION
## Summary
- include optional comment in signing payload and QR token so comments are signed
- show comment in verification details and restore comment input on signing form

## Testing
- `node --check app.js && echo 'app.js ok'`
- `node --check utils.js && echo 'utils.js ok'`


------
https://chatgpt.com/codex/tasks/task_e_68951f14bf7c83279538682baae6ba49