### PR TITLE
Add mobile sidebar toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -150,7 +150,13 @@ async function verifySig(algo, pubKey, bytes, sig) {
 
 // ---------- UI Tabs ----------
 const tabs = $$('.tab');
-$$('nav button').forEach(btn => btn.addEventListener('click', () => switchTab(btn.dataset.tab)));
+$$('nav button').forEach(btn => btn.addEventListener('click', () => {
+  switchTab(btn.dataset.tab);
+  if (window.innerWidth <= 700) document.body.classList.remove('nav-open');
+}));
+$('#menu-btn').addEventListener('click', () => {
+  document.body.classList.toggle('nav-open');
+});
 function switchTab(id) {
   document.querySelector('nav button.active')?.classList.remove('active');
   $(`nav button[data-tab="${id}"]`).classList.add('active');

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 </head>
 <body>
 <header>
+  <button id="menu-btn" class="menu-btn">☰</button>
   <h1>Client-Only Photo Signer & Verifier <span class="pill">Ed25519 / P-256</span> <span class="pill">No backend</span></h1>
   <div class="host">Deploy: upload this file to GitHub Pages</div>
 </header>

--- a/style.css
+++ b/style.css
@@ -23,6 +23,15 @@ header {
   align-items:center;
   justify-content:space-between;
 }
+header .menu-btn {
+  display:none;
+  background:none;
+  border:none;
+  color:var(--text);
+  font-size:24px;
+  margin-right:8px;
+  cursor:pointer;
+}
 header h1 {
   margin:0;
   font-size: 18px;
@@ -182,4 +191,32 @@ details { margin-top:8px; }
   border-radius:10px;
   padding:20px;
   text-align:center;
+}
+
+@media (max-width:700px) {
+  header {
+    justify-content:flex-start;
+  }
+  header .host {
+    display:none;
+  }
+  header .menu-btn {
+    display:block;
+  }
+  main {
+    grid-template-columns: 1fr;
+  }
+  nav {
+    position:fixed;
+    top:64px;
+    left:0;
+    bottom:0;
+    width:220px;
+    transform:translateX(-100%);
+    transition:transform .3s;
+    z-index:1000;
+  }
+  body.nav-open nav {
+    transform:translateX(0);
+  }
 }


### PR DESCRIPTION
## Summary
- add menu button to header and toggle logic for mobile
- style sidebar to slide in/out and hide host text on narrow screens

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68952cb287f4832799120e298d8a08e2