### PR TITLE
Use native WebCrypto with non‑exportable keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -5,6 +5,7 @@
 ### 1.1 User Identity Management
 - Create, manage, share (public key + name only), and delete identities.
 - Public keys shared via QR code or text.
+- Private keys remain non-exportable once generated.
 
 ### 1.2 Contacts Management
 - Import contacts using QR code or text input of public key + name.
@@ -25,7 +26,7 @@
 - Extract QR code and verify signature against hash.
 
 ## 2. Non-Functional Requirements
-- Private keys never leave device; use secure storage.
+- Private keys never leave device; use secure storage with non-exportable keys.
 - Signing and QR generation should complete in under 500 ms on typical devices.
 - Emphasize client-side operations for low-cost hosting.
 - Single codebase targeting web, iOS, and Android.
@@ -57,7 +58,7 @@
 
 ## 6. Framework and Tooling
 
-- **Frontend:** Expo (React Native + web). Use TypeScript, `expo-camera`, `expo-secure-store`, `noble-ed25519`, `jsqr`/`zxing`, `react-native-qrcode-svg`, `expo-sharing`.
+- **Frontend:** Expo (React Native + web). Use TypeScript, `expo-camera`, `expo-secure-store`, `jsqr`/`zxing`, `react-native-qrcode-svg`, `expo-sharing`.
 - **Backend:** Supabase or Firebase for storage, serverless functions, and optional profile lookup.
 
 ## 7. Hosting Suggestions
@@ -72,7 +73,7 @@
 ## 8. Development Workflow
 
 1. Initialize monorepo with Expo.
-2. Implement cryptographic utilities using `webcrypto` or `noble-ed25519`.
+2. Implement cryptographic utilities using WebCrypto.
 3. Build identity and contact management screens.
 4. Implement photo capture, hashing, signing, and QR overlay.
 5. Add sharing and verification screens.
@@ -83,7 +84,7 @@
 ## 9. Security Considerations
 
 - Use HTTPS for web.
-- Store private keys in secure storage; never transmit to backend.
+- Store private keys in secure storage as non-exportable keys; never transmit to backend.
 - Validate imported contacts to prevent malformed keys.
 - Treat QR code region as opaque when hashing.
 

--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 import {
-  $, $$, enc, dec, b64u, b64uToBytes, downloadBlob, listAll,
+  $, $$, enc, b64u, b64uToBytes, downloadBlob, listAll,
   drawToCanvas, computeHashWithBlackSquare, canvasToPngBytes, drawQR
 } from './utils.js';
 
@@ -10,142 +10,37 @@ const db = {
   captures: localforage.createInstance({ name: 'photo-signer', storeName: 'captures' }),
 };
 
-// ---------- Crypto: WebCrypto + noble fallback ----------
-const hasEd25519 = (() => {
-  try {
-    crypto.subtle.generateKey({ name: 'Ed25519', namedCurve: 'Ed25519' }, false, ['sign', 'verify']);
-    return true;
-  } catch { return false; }
-})();
-
-async function importPubKey(algo, rawOrJwk) {
+// ---------- Crypto: WebCrypto only ----------
+async function importPubKey(rawOrJwk) {
   if (typeof rawOrJwk === 'string') {
     try { rawOrJwk = JSON.parse(rawOrJwk); } catch {}
   }
-  if (algo === 'Ed25519') {
-    if (rawOrJwk.kty === 'OKP' && rawOrJwk.crv === 'Ed25519' && rawOrJwk.x) {
-      const raw = b64uToBytes(rawOrJwk.x);
-      try {
-        return await crypto.subtle.importKey('raw', raw, { name:'Ed25519' }, true, ['verify']);
-      } catch (e) {
-        return { noble:true, algo:'Ed25519', raw };
-      }
-    } else {
-      const raw = typeof rawOrJwk === 'string' ? b64uToBytes(rawOrJwk) : new Uint8Array(rawOrJwk);
-      try { return await crypto.subtle.importKey('raw', raw, { name:'Ed25519' }, true, ['verify']); }
-      catch { return { noble:true, algo:'Ed25519', raw }; }
-    }
-  } else if (algo === 'P-256') {
-    if (rawOrJwk.kty) {
-      return await crypto.subtle.importKey('jwk', rawOrJwk, { name:'ECDSA', namedCurve:'P-256' }, true, ['verify']);
-    } else {
-      throw new Error('Provide P-256 public key as JWK');
-    }
+  if (rawOrJwk.kty === 'OKP' && rawOrJwk.crv === 'Ed25519' && rawOrJwk.x) {
+    const raw = b64uToBytes(rawOrJwk.x);
+    return await crypto.subtle.importKey('raw', raw, { name: 'Ed25519' }, true, ['verify']);
   }
-  throw new Error('Unsupported algo');
+  const raw = typeof rawOrJwk === 'string' ? b64uToBytes(rawOrJwk) : new Uint8Array(rawOrJwk);
+  return await crypto.subtle.importKey('raw', raw, { name: 'Ed25519' }, true, ['verify']);
 }
 
-async function genKey(algo) {
-  if (algo === 'Ed25519') {
-    try {
-      const key = await crypto.subtle.generateKey({ name:'Ed25519', namedCurve:'Ed25519' }, true, ['sign','verify']);
-      const pubRaw = new Uint8Array(await crypto.subtle.exportKey('raw', key.publicKey));
-      const pubJwk = await crypto.subtle.exportKey('jwk', key.publicKey);
-      return { algo, key, pubRaw, pubJwk };
-    } catch (e) {
-      const priv = nobleEd25519.utils.randomPrivateKey();
-      const pubRaw = await nobleEd25519.getPublicKeyAsync(priv);
-      return { algo, noble:true, priv, pubRaw, pubJwk: { kty:'OKP', crv:'Ed25519', x: b64u(pubRaw) } };
-    }
-  } else if (algo === 'P-256') {
-    const key = await crypto.subtle.generateKey({ name:'ECDSA', namedCurve:'P-256' }, true, ['sign','verify']);
-    const pubJwk = await crypto.subtle.exportKey('jwk', key.publicKey);
-    const x = pubJwk.x;
-    return { algo, key, pubRaw: b64uToBytes(x), pubJwk };
-  }
-  throw new Error('Unsupported algo');
-}
-
-async function exportPrivateEncrypted(idRec, passphrase) {
-  const salt = crypto.getRandomValues(new Uint8Array(16));
-  const iv = crypto.getRandomValues(new Uint8Array(12));
-  const keyMat = await crypto.subtle.importKey('raw', enc.encode(passphrase || ''), 'PBKDF2', false, ['deriveKey']);
-  const aesKey = await crypto.subtle.deriveKey({ name:'PBKDF2', salt, iterations: 200_000, hash:'SHA-256' }, keyMat, { name:'AES-GCM', length:256 }, false, ['encrypt']);
-
-  let privBytes, privJwk;
-  if (idRec.noble) {
-    privBytes = idRec.priv;
-    privJwk = { kty:'OKP', crv:'Ed25519', d: b64u(privBytes), x: b64u(idRec.pubRaw) };
-  } else {
-    privJwk = await crypto.subtle.exportKey('jwk', idRec.key.privateKey);
-    privBytes = enc.encode(JSON.stringify(privJwk));
-  }
-  const plaintext = idRec.noble ? enc.encode(JSON.stringify(privJwk)) : privBytes;
-  const ciphertext = new Uint8Array(await crypto.subtle.encrypt({ name:'AES-GCM', iv }, aesKey, plaintext));
-  return {
-    name: idRec.name,
-    algo: idRec.algo,
-    salt: b64u(salt), iv: b64u(iv), ct: b64u(ciphertext)
-  };
-}
-
-async function importPrivateEncrypted(payload, passphrase) {
-  const salt = b64uToBytes(payload.salt); const iv = b64uToBytes(payload.iv); const ct = b64uToBytes(payload.ct);
-  const keyMat = await crypto.subtle.importKey('raw', enc.encode(passphrase || ''), 'PBKDF2', false, ['deriveKey']);
-  const aesKey = await crypto.subtle.deriveKey({ name:'PBKDF2', salt, iterations: 200_000, hash:'SHA-256' }, keyMat, { name:'AES-GCM', length:256 }, false, ['decrypt']);
-  const plain = new Uint8Array(await crypto.subtle.decrypt({ name:'AES-GCM', iv }, aesKey, ct));
-  const jwk = JSON.parse(dec.decode(plain));
-  if (payload.algo === 'Ed25519') {
-    try {
-      const priv = await crypto.subtle.importKey('jwk', jwk, { name:'Ed25519', namedCurve:'Ed25519' }, true, ['sign']);
-      const pub = await crypto.subtle.importKey('jwk', { kty:'OKP', crv:'Ed25519', x:jwk.x }, { name:'Ed25519' }, true, ['verify']);
-      const pubRaw = new Uint8Array(await crypto.subtle.exportKey('raw', pub));
-      return { name: payload.name, algo:'Ed25519', key: { privateKey: priv, publicKey: pub }, pubRaw, pubJwk: { kty:'OKP', crv:'Ed25519', x:jwk.x } };
-    } catch (e) {
-      const priv = b64uToBytes(jwk.d);
-      const pubRaw = await nobleEd25519.getPublicKeyAsync(priv);
-      return { name: payload.name, algo:'Ed25519', noble:true, priv, pubRaw, pubJwk:{ kty:'OKP', crv:'Ed25519', x:b64u(pubRaw) } };
-    }
-  } else if (payload.algo === 'P-256') {
-    const priv = await crypto.subtle.importKey('jwk', jwk, { name:'ECDSA', namedCurve:'P-256' }, true, ['sign']);
-    const pub = await crypto.subtle.importKey('jwk', { ...jwk, d: undefined }, { name:'ECDSA', namedCurve:'P-256' }, true, ['verify']);
-    const pubJwk = await crypto.subtle.exportKey('jwk', pub);
-    return { name: payload.name, algo:'P-256', key: { privateKey: priv, publicKey: pub }, pubRaw: b64uToBytes(pubJwk.x), pubJwk };
-  }
-  throw new Error('Unsupported');
+async function genKey() {
+  const key = await crypto.subtle.generateKey(
+    { name: 'Ed25519', namedCurve: 'Ed25519' },
+    false,
+    ['sign', 'verify']
+  );
+  const pubRaw = new Uint8Array(await crypto.subtle.exportKey('raw', key.publicKey));
+  const pubJwk = await crypto.subtle.exportKey('jwk', key.publicKey);
+  return { algo: 'Ed25519', key, pubRaw, pubJwk };
 }
 
 async function signBytes(idRec, bytes) {
-  if (idRec.algo === 'Ed25519') {
-    if (idRec.noble) {
-      const sig = await nobleEd25519.signAsync(bytes, idRec.priv);
-      return new Uint8Array(sig);
-    } else {
-      const sig = await crypto.subtle.sign({ name:'Ed25519' }, idRec.key.privateKey, bytes);
-      return new Uint8Array(sig);
-    }
-  } else if (idRec.algo === 'P-256') {
-    const sig = await crypto.subtle.sign({ name:'ECDSA', hash: 'SHA-256' }, idRec.key.privateKey, bytes);
-    return new Uint8Array(sig);
-  }
-  throw new Error('Unsupported algo');
+  const sig = await crypto.subtle.sign({ name: 'Ed25519' }, idRec.key.privateKey, bytes);
+  return new Uint8Array(sig);
 }
 
-async function verifySig(algo, pubKey, bytes, sig) {
-  if (algo === 'Ed25519') {
-    if (pubKey && pubKey.noble) {
-      return await nobleEd25519.verifyAsync(sig, bytes, pubKey.raw);
-    }
-    try {
-      return await crypto.subtle.verify({ name:'Ed25519' }, pubKey, sig, bytes);
-    } catch (e) {
-      if (pubKey && pubKey.raw) return await nobleEd25519.verifyAsync(sig, bytes, pubKey.raw);
-      throw e;
-    }
-  } else if (algo === 'P-256') {
-    return await crypto.subtle.verify({ name:'ECDSA', hash:'SHA-256' }, pubKey, sig, bytes);
-  }
-  throw new Error('Unsupported algo');
+async function verifySig(pubKey, bytes, sig) {
+  return await crypto.subtle.verify({ name: 'Ed25519' }, pubKey, sig, bytes);
 }
 
 // ---------- UI Tabs ----------
@@ -176,7 +71,6 @@ async function refreshIdentities() {
         <div class="mono muted">pk: ${b64u(value.pubRaw)}</div>
         <div style="margin-top:6px" class="row">
           <button class="btn" data-share="${key}">Share</button>
-          <button class="btn" data-export="${key}">Export Private (encrypted)</button>
           <button class="btn warn" data-del="${key}">Delete</button>
         </div>
       `;
@@ -192,9 +86,8 @@ async function refreshIdentities() {
 
 $('#btn-create-id').addEventListener('click', async () => {
   const name = $('#id-name').value.trim() || 'Unnamed';
-  const algo = $('#id-algo').value;
-  const k = await genKey(algo);
-  const rec = { name, algo, ...k };
+  const k = await genKey();
+  const rec = { name, algo: 'Ed25519', ...k };
   const id = crypto.randomUUID();
   await db.ids.setItem(id, rec);
   await refreshIdentities();
@@ -209,13 +102,6 @@ $('#identity-list').addEventListener('click', async (e) => {
     await QRCode.toCanvas($('#share-qr'), JSON.stringify(payload), { errorCorrectionLevel: 'M', margin: 1, width: 256 });
     $('#share-name').textContent = rec.name;
     $('#share-modal').style.display = 'flex';
-  } else if (t.dataset.export) {
-    const id = t.dataset.export; const rec = await db.ids.getItem(id);
-    const pass = $('#id-pass').value || prompt('Passphrase to encrypt private key export:');
-    if (!pass) return;
-    const payload = await exportPrivateEncrypted(rec, pass);
-    const blob = new Blob([JSON.stringify(payload, null, 2)], { type:'application/json' });
-    downloadBlob(`identity-${rec.name}.priv.enc.json`, blob);
   } else if (t.dataset.del) {
     if (!confirm('Delete identity?')) return;
     await db.ids.removeItem(t.dataset.del);
@@ -225,18 +111,6 @@ $('#identity-list').addEventListener('click', async (e) => {
 
 $('#share-close').addEventListener('click', () => {
   $('#share-modal').style.display = 'none';
-});
-
-$('#btn-import-id').addEventListener('click', async () => {
-  try {
-    const json = JSON.parse($('#id-import-json').value);
-    const pass = $('#id-import-pass').value;
-    const rec = await importPrivateEncrypted(json, pass);
-    const id = crypto.randomUUID();
-    await db.ids.setItem(id, rec);
-    await refreshIdentities();
-    alert('Imported identity');
-  } catch (e) { alert('Import failed: ' + e.message); }
 });
 
 // ---------- Contacts ----------
@@ -260,11 +134,10 @@ async function refreshContacts() {
 
 $('#btn-add-contact').addEventListener('click', async () => {
   const displayName = $('#contact-name').value.trim();
-  const algo = $('#contact-algo').value;
   let publicJwk = $('#contact-pub').value.trim();
   try { publicJwk = JSON.parse(publicJwk); } catch {}
   const id = crypto.randomUUID();
-  await db.contacts.setItem(id, { displayName, algo, publicJwk });
+  await db.contacts.setItem(id, { displayName, algo: 'Ed25519', publicJwk });
   await refreshContacts();
   alert('Contact saved');
 });
@@ -377,14 +250,15 @@ async function verifyFromCanvas(canvas) {
   if (!code) return { verified:false, reason:'No QR found' };
   let token; try { token = JSON.parse(code.data); } catch { return { verified:false, reason:'QR not JSON' }; }
   const { v, alg, pk, ts, ih, c, p, n, sig } = token;
+  if (alg !== 'Ed25519') return { verified:false, reason:'Unsupported algorithm', details:{ alg } };
   const { hash } = await computeHashWithBlackSquare(canvas, c, p);
   const hashB64 = b64u(hash);
   const payload = { version:1, algo:alg, imageHash:hashB64, signerPub:pk, timestamp:ts, corner:c, percent:p, optional:{ note:n } };
   const payloadBytes = enc.encode(JSON.stringify(payload));
   let pub;
-  try { pub = await importPubKey(alg, { kty:'OKP', crv:'Ed25519', x: pk }); }
-  catch { try { pub = await importPubKey(alg, pk); } catch (e) { pub = { noble:true, raw: b64uToBytes(pk) }; } }
-  const ok = await verifySig(alg, pub, payloadBytes, b64uToBytes(sig));
+  try { pub = await importPubKey({ kty:'OKP', crv:'Ed25519', x: pk }); }
+  catch { pub = await importPubKey(pk); }
+  const ok = await verifySig(pub, payloadBytes, b64uToBytes(sig));
   return {
     verified: ok && (hashB64 === ih),
     reason: ok ? (hashB64===ih? 'OK':'Hash mismatch') : 'Bad signature',
@@ -419,34 +293,6 @@ $('#btn-verify-url').addEventListener('click', async () => {
   } catch (e) {
     $('#verify-report').textContent = JSON.stringify({ verified:false, reason:'Fetch failed or CORS blocked', error:e.message }, null, 2);
   }
-});
-
-// ---------- Backup/Restore ----------
-$('#btn-backup').addEventListener('click', async () => {
-  const pass = $('#backup-pass').value || prompt('Passphrase to encrypt private keys in backup:');
-  const ids = await listAll(db.ids);
-  const contacts = await listAll(db.contacts);
-  const out = { version:1, when:new Date().toISOString(), identities:[], contacts: contacts.map(x=>x.value) };
-  for (const { value } of ids) out.identities.push(await exportPrivateEncrypted(value, pass));
-  downloadBlob('photosigner-backup.json', new Blob([JSON.stringify(out, null, 2)], { type:'application/json' }));
-});
-
-$('#btn-restore').addEventListener('click', async () => {
-  try {
-    const json = JSON.parse($('#restore-json').value);
-    const pass = $('#restore-pass').value || prompt('Backup passphrase:');
-    if (json.contacts) {
-      for (const c of json.contacts) await db.contacts.setItem(crypto.randomUUID(), c);
-    }
-    if (json.identities) {
-      for (const i of json.identities) {
-        const rec = await importPrivateEncrypted(i, pass);
-        await db.ids.setItem(crypto.randomUUID(), rec);
-      }
-    }
-    await refreshIdentities(); await refreshContacts();
-    alert('Restore complete');
-  } catch (e) { alert('Restore failed: '+e.message); }
 });
 
 // ---------- Init ----------

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
 <header>
   <button id="menu-btn" class="menu-btn">☰</button>
-  <h1>Client-Only Photo Signer & Verifier <span class="pill">Ed25519 / P-256</span> <span class="pill">No backend</span></h1>
+  <h1>Client-Only Photo Signer & Verifier <span class="pill">Ed25519</span> <span class="pill">No backend</span></h1>
   <div class="host">Deploy: upload this file to GitHub Pages</div>
 </header>
 <main>
@@ -19,7 +19,6 @@
     <button data-tab="contacts">Contacts</button>
     <button data-tab="capture">Capture & Sign</button>
     <button data-tab="verify">Verify</button>
-    <button data-tab="backup">Backup</button>
     <hr style="border-color:var(--muted); opacity:.5">
     <button data-tab="about">About</button>
   </nav>
@@ -30,17 +29,6 @@
         <div>
           <label>Display name</label>
           <input id="id-name" type="text" placeholder="e.g., Alice Photographer" />
-        </div>
-        <div>
-          <label>Algorithm</label>
-          <select id="id-algo">
-            <option value="Ed25519" selected>Ed25519 (preferred)</option>
-            <option value="P-256">P-256 (ECDSA)</option>
-          </select>
-        </div>
-        <div>
-          <label>Passphrase (encrypt private key export)</label>
-          <input id="id-pass" type="password" placeholder="Optional (recommended for export)" />
         </div>
       </div>
       <div style="margin-top:8px">
@@ -53,17 +41,6 @@
       <div id="identity-list" class="grid"></div>
     </div>
 
-    <div class="card">
-      <h2>Import Private Identity</h2>
-      <p class="muted">Paste an encrypted private JWK export produced by this app. Decrypts with your passphrase.</p>
-      <label>Encrypted Export (JSON)</label>
-      <textarea id="id-import-json" rows="6" class="mono" placeholder='{"name":"...","algo":"Ed25519", ...}'></textarea>
-      <label>Passphrase</label>
-      <input id="id-import-pass" type="password" />
-      <div style="margin-top:8px">
-        <button class="btn" id="btn-import-id">Import</button>
-      </div>
-    </div>
   </section>
 
   <section id="contacts" class="tab" style="display:none">
@@ -73,13 +50,6 @@
         <div>
           <label>Display name</label>
           <input id="contact-name" type="text" />
-        </div>
-        <div>
-          <label>Algorithm</label>
-          <select id="contact-algo">
-            <option value="Ed25519" selected>Ed25519</option>
-            <option value="P-256">P-256</option>
-          </select>
         </div>
       </div>
       <label>Public Key (Base64URL or JWK)</label>
@@ -187,34 +157,12 @@
     </div>
   </section>
 
-  <section id="backup" class="tab" style="display:none">
-    <div class="card">
-      <h2>Backup / Restore</h2>
-      <div class="row">
-        <div>
-          <label>Export Passphrase (for private keys)</label>
-          <input id="backup-pass" type="password" />
-        </div>
-      </div>
-      <div style="margin-top:8px">
-        <button class="btn" id="btn-backup">Export Backup JSON</button>
-      </div>
-      <h3>Restore</h3>
-      <textarea id="restore-json" rows="8" class="mono" placeholder="Paste backup JSON"></textarea>
-      <label>Restore Passphrase</label>
-      <input id="restore-pass" type="password" />
-      <div style="margin-top:8px">
-        <button class="btn" id="btn-restore">Restore</button>
-      </div>
-    </div>
-  </section>
-
   <section id="about" class="tab" style="display:none">
     <div class="card">
       <h2>About</h2>
       <p>This single-file SPA implements a client-only photo signing and verification workflow: local identities, deterministic hashing with a blackened QR region, QR embedding, and verification.</p>
       <ul class="kvl">
-        <li>Keys: Ed25519 (preferred) via WebCrypto, with P-256 fallback; @noble/ed25519 as optional fallback.</li>
+        <li>Keys: Ed25519 via WebCrypto.</li>
         <li>QR: generated client-side; read via jsQR.</li>
         <li>Storage: IndexedDB via localForage.</li>
         <li>No build step. Deploy this <code>index.html</code> on GitHub Pages.</li>
@@ -237,8 +185,6 @@
 <script src="https://cdn.jsdelivr.net/npm/localforage@1.10.0/dist/localforage.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@noble/ed25519@2.1.0/lib/index.umd.min.js"></script>
-
 <script type="module" src="app.js"></script>
 
 </body>


### PR DESCRIPTION
## Summary
- drop noble and P-256 support and rely solely on WebCrypto Ed25519 keys
- generate non-exportable private keys and allow only sharing or deletion
- clean up UI/docs for Ed25519-only workflow and non-exportable keys

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6898880b89988327b24453e39ed1835f